### PR TITLE
[step10] 유저포인트 & 좌석 예약 동시성 통합 테스트 작성

### DIFF
--- a/src/main/java/com/hanghae/concert_reservation/domain/concert/entity/ConcertSeat.java
+++ b/src/main/java/com/hanghae/concert_reservation/domain/concert/entity/ConcertSeat.java
@@ -39,6 +39,9 @@ public class ConcertSeat {
     @Column(nullable = false)
     private LocalDateTime updatedAt;
 
+    @Version
+    private Long version;
+
     private ConcertSeat(Long concertScheduleId, int seatNumber, BigDecimal price) {
         this.concertScheduleId = concertScheduleId;
         this.seatNumber = seatNumber;

--- a/src/main/java/com/hanghae/concert_reservation/infrastructure/concert/repository/ConcertRepositoryImpl.java
+++ b/src/main/java/com/hanghae/concert_reservation/infrastructure/concert/repository/ConcertRepositoryImpl.java
@@ -38,10 +38,9 @@ public class ConcertRepositoryImpl implements ConcertRepository {
         return concertSeatJpaRepository.getConcertSeats(concertScheduleId);
     }
 
-    @Lock(LockModeType.OPTIMISTIC)
     @Override
     public ConcertSeat getConcertSeat(Long concertSeatId) {
-        return concertSeatJpaRepository.findById(concertSeatId)
+        return concertSeatJpaRepository.findByIdWithOptimisticLock(concertSeatId)
                 .orElseThrow(() -> new BizNotFoundException("콘서트 좌석을 찾을 수 없습니다."));
     }
 

--- a/src/main/java/com/hanghae/concert_reservation/infrastructure/concert/repository/ConcertSeatJpaRepository.java
+++ b/src/main/java/com/hanghae/concert_reservation/infrastructure/concert/repository/ConcertSeatJpaRepository.java
@@ -1,14 +1,21 @@
 package com.hanghae.concert_reservation.infrastructure.concert.repository;
 
 import com.hanghae.concert_reservation.domain.concert.entity.ConcertSeat;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ConcertSeatJpaRepository extends JpaRepository<ConcertSeat, Long> {
 
     @Query("SELECT cs FROM ConcertSeat cs WHERE cs.concertScheduleId = :concertScheduleId")
     List<ConcertSeat> getConcertSeats(@Param("concertScheduleId") Long concertScheduleId);
+
+    @Lock(LockModeType.OPTIMISTIC)
+    @Query("SELECT cs FROM ConcertSeat cs WHERE cs.id = :concertSeatId AND cs.concertSeatStatus = 'AVAILABLE'")
+    Optional<ConcertSeat> findByIdWithOptimisticLock(@Param("concertSeatId") Long concertSeatId);
 }

--- a/src/main/java/com/hanghae/concert_reservation/infrastructure/user/repository/UserPointJpaRepository.java
+++ b/src/main/java/com/hanghae/concert_reservation/infrastructure/user/repository/UserPointJpaRepository.java
@@ -1,7 +1,17 @@
 package com.hanghae.concert_reservation.infrastructure.user.repository;
 
 import com.hanghae.concert_reservation.domain.user.entity.UserPoint;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface UserPointJpaRepository extends JpaRepository<UserPoint, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT up FROM UserPoint up WHERE up.userId = :userId")
+    Optional<UserPoint> findByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/hanghae/concert_reservation/infrastructure/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/hanghae/concert_reservation/infrastructure/user/repository/UserRepositoryImpl.java
@@ -16,7 +16,7 @@ public class UserRepositoryImpl implements UserRepository {
 
     @Override
     public UserPoint getPointByUserId(Long userId) {
-        return userPointJpaRepository.findById(userId)
+        return userPointJpaRepository.findByUserId(userId)
                 .orElseThrow(() -> new BizNotFoundException("유저 포인트가 없습니다."));
     }
 

--- a/src/test/java/com/hanghae/concert_reservation/application/concert/concurrent/ConcertReservationConcurrencyTest.java
+++ b/src/test/java/com/hanghae/concert_reservation/application/concert/concurrent/ConcertReservationConcurrencyTest.java
@@ -1,0 +1,123 @@
+package com.hanghae.concert_reservation.application.concert.concurrent;
+
+import com.hanghae.concert_reservation.domain.concert.dto.command.ConcertSeatReservationCommand;
+import com.hanghae.concert_reservation.domain.concert.entity.Concert;
+import com.hanghae.concert_reservation.domain.concert.entity.ConcertSchedule;
+import com.hanghae.concert_reservation.domain.concert.entity.ConcertSeat;
+import com.hanghae.concert_reservation.domain.concert.service.ConcertService;
+import com.hanghae.concert_reservation.infrastructure.concert.repository.ConcertJpaRepository;
+import com.hanghae.concert_reservation.infrastructure.concert.repository.ConcertScheduleJpaRepository;
+import com.hanghae.concert_reservation.infrastructure.concert.repository.ConcertSeatJpaRepository;
+import com.hanghae.concert_reservation.infrastructure.concert.repository.ReservationJpaRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class ConcertReservationConcurrencyTest {
+
+    @Autowired
+    private ConcertJpaRepository concertJpaRepository;
+
+    @Autowired
+    private ConcertScheduleJpaRepository concertScheduleJpaRepository;
+
+    @Autowired
+    private ConcertSeatJpaRepository concertSeatJpaRepository;
+
+    @Autowired
+    private ReservationJpaRepository reservationJpaRepository;
+
+    @Autowired
+    private ConcertService concertService;
+
+    @BeforeEach
+    void setUp() {
+        reservationJpaRepository.deleteAll();
+        concertSeatJpaRepository.deleteAll();
+        concertScheduleJpaRepository.deleteAll();
+        concertJpaRepository.deleteAll();
+
+        Concert concert = concertJpaRepository.save(Concert.of("아이유콘서트"));
+        ConcertSchedule concertSchedule = concertScheduleJpaRepository.save(ConcertSchedule.of(concert.getId(), LocalDateTime.now(), "콘서트홀"));
+        concertSeatJpaRepository.save(ConcertSeat.of(concertSchedule.getId(), 1, BigDecimal.valueOf(100000)));
+    }
+
+    @Test
+    void shouldAllowOnlyOneUserToReserveSeatWhenMultipleRequestsAreMadeSimultaneously() throws InterruptedException {
+        // given
+        int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failedCount = new AtomicInteger(0);
+
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            final int index = i;
+            executorService.submit(() -> {
+                try {
+                    ConcertSeatReservationCommand command = new ConcertSeatReservationCommand((long) index + 1, 1L, 1L, 1L);
+                    concertService.reservation(command);
+                    successCount.incrementAndGet();
+                } catch (ObjectOptimisticLockingFailureException e) {
+                    failedCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        assertThat(successCount.get()).isEqualTo(1);
+        assertThat(failedCount.get()).isEqualTo(9);
+    }
+
+    @Test
+    void shouldAllowOnlyOneReservationWhenSameUserAttemptsToReserveSameSeatSimultaneously() throws InterruptedException {
+        // given
+        int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failedCount = new AtomicInteger(0);
+
+        ConcertSeatReservationCommand command = new ConcertSeatReservationCommand(1L, 1L, 1L, 1L);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    concertService.reservation(command);
+                    successCount.incrementAndGet();
+                } catch (ObjectOptimisticLockingFailureException e) {
+                    failedCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        // then
+        assertThat(successCount.get()).isEqualTo(1);
+        assertThat(failedCount.get()).isEqualTo(9);
+    }
+}

--- a/src/test/java/com/hanghae/concert_reservation/application/payment/interactor/ConcertPaymentInteractorTest.java
+++ b/src/test/java/com/hanghae/concert_reservation/application/payment/interactor/ConcertPaymentInteractorTest.java
@@ -56,7 +56,7 @@ class ConcertPaymentInteractorTest {
         Reservation reservation = concertRepository.save(Reservation.of(userPoint.getUserId(), concertSeat.getId(), concert.getName(), schedule.getDate(), concertSeat.getPrice()));
         reservation.setToTemporaryReservationTime();
 
-        PaymentCommand command = new PaymentCommand(userPoint.getId(), reservation.getId());
+        PaymentCommand command = new PaymentCommand(userPoint.getUserId(), reservation.getId());
 
         // when
         PaymentResponse result = concertPaymentInteractor.payment(command);

--- a/src/test/java/com/hanghae/concert_reservation/application/user/concurrent/UserPointConcurrencyTest.java
+++ b/src/test/java/com/hanghae/concert_reservation/application/user/concurrent/UserPointConcurrencyTest.java
@@ -1,0 +1,62 @@
+package com.hanghae.concert_reservation.application.user.concurrent;
+
+import com.hanghae.concert_reservation.domain.user.constant.UserPointTransactionType;
+import com.hanghae.concert_reservation.domain.user.dto.command.UserPointChargeCommand;
+import com.hanghae.concert_reservation.domain.user.entity.UserPoint;
+import com.hanghae.concert_reservation.domain.user.service.UserService;
+import com.hanghae.concert_reservation.infrastructure.user.repository.UserPointJpaRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.math.BigDecimal;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class UserPointConcurrencyTest {
+
+    @Autowired
+    private UserPointJpaRepository userPointJpaRepository;
+
+    @Autowired
+    private UserService userService;
+
+    @AfterEach
+    void tearDown() {
+        userPointJpaRepository.deleteAll();
+    }
+
+    @Test
+    void shouldHandleConcurrentPointCharging() throws InterruptedException {
+        // given
+        UserPoint userPoint = userPointJpaRepository.save(UserPoint.of(1L, BigDecimal.valueOf(0)));
+        UserPointChargeCommand command = new UserPointChargeCommand(userPoint.getUserId(), BigDecimal.valueOf(10000), UserPointTransactionType.CHARGE);
+
+        int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    userService.userPointCharge(command);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        // then
+        UserPoint res = userPointJpaRepository.findById(userPoint.getId()).get();
+        assertThat(res.getBalance().longValue()).isEqualTo(BigDecimal.valueOf(100000).longValue());
+    }
+}

--- a/src/test/java/com/hanghae/concert_reservation/application/user/interactor/GetUserPointInteractorTest.java
+++ b/src/test/java/com/hanghae/concert_reservation/application/user/interactor/GetUserPointInteractorTest.java
@@ -28,7 +28,7 @@ class GetUserPointInteractorTest {
         UserPoint userPoint = userPointJpaRepository.save(UserPoint.of(1L, BigDecimal.valueOf(0)));
 
         // when
-        UserPointResponse result = getUserPointInteractor.getUserPoints(userPoint.getId());
+        UserPointResponse result = getUserPointInteractor.getUserPoints(userPoint.getUserId());
 
         // then
         assertThat(result).isNotNull();

--- a/src/test/java/com/hanghae/concert_reservation/application/user/interactor/UserPointChargeInteractorTest.java
+++ b/src/test/java/com/hanghae/concert_reservation/application/user/interactor/UserPointChargeInteractorTest.java
@@ -27,7 +27,7 @@ class UserPointChargeInteractorTest {
     void userPointCharge() {
         // given
         UserPoint userPoint = userPointJpaRepository.save(UserPoint.of(1L, BigDecimal.valueOf(0)));
-        UserPointChargeCommand command = new UserPointChargeCommand(userPoint.getId(), BigDecimal.valueOf(10000), UserPointTransactionType.CHARGE);
+        UserPointChargeCommand command = new UserPointChargeCommand(userPoint.getUserId(), BigDecimal.valueOf(10000), UserPointTransactionType.CHARGE);
 
         // when
         userPointChargeInteractor.userPointCharge(command);


### PR DESCRIPTION
### [작업 내용]
1. 유저 포인트 충전 동시성 테스트 작성
2. 좌석 예약 동시성 테스트 작성
3. [chapter2. 회고 작성](https://choicode.tistory.com/43)

### [의사결정]
1. 유저가 포인트를 각각 다른 기기에서 동시에 충전할 수 있는 경우를 생각했습니다.
    요청한 대로 금액만 정상적이라면 모두 성공해야 한다고 판단했고, 잔액 관리가 필요하기 때문에 비관적 락을 사용하였습니다.
2. 좌석 예약은 하나의 좌석을 누군가 점유하면 5분간 점유가 되기 때문에 선행된 트랜잭션이 끝날 때까지 기다릴 필요가 없다고 생각했습니다.
    따라서 좌석이 이미 점유됐다면 나머지 사람들(동시 요청한 본인 포함)은 재시도 로직을 실행하지 않는 낙관적 락을 사용하기로 결정했습니다.

### [리뷰 포인트]
상황에 맞게 비관적 락과 낙관적 락을 적절하게 사용하였는지 리뷰 부탁드리겠습니다!