### PR TITLE
[Step17] kafka 적용 및 연동 테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 	implementation 'org.redisson:redisson:3.38.0'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.kafka:spring-kafka'
+	testImplementation 'org.springframework.kafka:spring-kafka-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hanghae/concert_reservation/common/support/scheduler/config/SchedulerConfig.java
+++ b/src/main/java/com/hanghae/concert_reservation/common/support/scheduler/config/SchedulerConfig.java
@@ -2,10 +2,12 @@ package com.hanghae.concert_reservation.common.support.scheduler.config;
 
 import com.hanghae.concert_reservation.domain.waiting_queue.repository.WaitingQueueRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 
+@Slf4j
 @RequiredArgsConstructor
 @EnableScheduling
 @Configuration
@@ -16,8 +18,12 @@ public class SchedulerConfig {
     /**
      * 대기열에서 활성열로 이동
      */
-    @Scheduled(fixedRate = 60000)
+//    @Scheduled(fixedRate = 60000)
     public void moveToActiveQueue() {
-        waitingQueueRepository.moveToActiveQueue();
+        try {
+            waitingQueueRepository.moveToActiveQueue();
+        } catch (Exception e) {
+            log.error("[ERROR] queue moveToActiveQueue failed={}", e.getMessage(), e);
+        }
     }
 }

--- a/src/main/java/com/hanghae/concert_reservation/domain/payment/kafka/KafkaConsumer.java
+++ b/src/main/java/com/hanghae/concert_reservation/domain/payment/kafka/KafkaConsumer.java
@@ -1,0 +1,26 @@
+package com.hanghae.concert_reservation.domain.payment.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class KafkaConsumer {
+
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(topics = "my-topic", groupId = "my-group")
+    public void listen(byte[] message, Acknowledgment acknowledgment) {
+        try {
+            String receivedMessage = objectMapper.readValue(message, String.class);
+            acknowledgment.acknowledge();
+        } catch (Exception e) {
+            log.error("[ERROR] Processing failed={}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/hanghae/concert_reservation/domain/payment/kafka/KafkaController.java
+++ b/src/main/java/com/hanghae/concert_reservation/domain/payment/kafka/KafkaController.java
@@ -1,0 +1,21 @@
+package com.hanghae.concert_reservation.domain.payment.kafka;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/kafka")
+public class KafkaController {
+
+    private final KafkaProducer kafkaProducer;
+
+    @PostMapping("/send")
+    public String sendMessage(@RequestParam String message) {
+        kafkaProducer.sendMessage("my-topic", message);
+        return "Message sent: " + message;
+    }
+}

--- a/src/main/java/com/hanghae/concert_reservation/domain/payment/kafka/KafkaProducer.java
+++ b/src/main/java/com/hanghae/concert_reservation/domain/payment/kafka/KafkaProducer.java
@@ -1,0 +1,16 @@
+package com.hanghae.concert_reservation.domain.payment.kafka;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class KafkaProducer {
+
+    private final KafkaTemplate<Object, Object> kafkaTemplate;
+
+    public void sendMessage(String topic, Object message) {
+        kafkaTemplate.send(topic, message);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,3 +26,17 @@ spring:
       port: 6379
   cache:
     type: redis
+  kafka:
+    bootstrap-servers: localhost:9092
+    producer:
+      acks: all
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+    consumer:
+      group-id: my-group
+      auto-offset-reset: earliest
+      enable-auto-commit: false
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.ByteArrayDeserializer
+    listener:
+      ack-mode: manual

--- a/src/main/resources/docker-compose.yml
+++ b/src/main/resources/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  zookeeper:
+    image: bitnami/zookeeper:latest
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+      - ZOO_TLS_CLIENT_AUTH=none
+      - ZOO_TLS_QUORUM_CLIENT_AUTH=none
+  kafka:
+    image: bitnami/kafka:latest
+    container_name: kafka
+    ports:
+      - "9092:9092"
+    environment:
+      - KAFKA_BROKER_ID=1
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+    depends_on:
+      - zookeeper

--- a/src/test/java/com/hanghae/concert_reservation/domain/payment/kafka/KafkaProducerTest.java
+++ b/src/test/java/com/hanghae/concert_reservation/domain/payment/kafka/KafkaProducerTest.java
@@ -1,0 +1,44 @@
+package com.hanghae.concert_reservation.domain.payment.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@EmbeddedKafka(partitions = 1, topics = {"test-topic"}, brokerProperties = {"listeners=PLAINTEXT://localhost:9092", "port=9092"})
+public class KafkaProducerTest {
+
+    @Autowired
+    private KafkaProducer kafkaProducer;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private static String receivedMessage;
+
+    @KafkaListener(topics = "test-topic", groupId = "test-group")
+    public void listen(byte[] message) throws IOException {
+        receivedMessage = objectMapper.readValue(message, String.class);
+        System.out.println("receivedMessage = " + receivedMessage);
+    }
+
+    @Test
+    void testSendMessage() throws InterruptedException {
+        // Given
+        String topic = "test-topic";
+        Object message = "{message: test topic message}";
+
+        // When
+        kafkaProducer.sendMessage(topic, message);
+        Thread.sleep(2000);
+
+        // Then
+        assertThat(receivedMessage).isEqualTo(message);
+    }
+}


### PR DESCRIPTION
## [작업 내용]
1. docker container에 kafka 올리고 docker cli로 테스트해보기
<img width="230" alt="image" src="https://github.com/user-attachments/assets/7f53d075-634f-4ee0-bf25-7472cfe7e602">
<img width="300" alt="image" src="https://github.com/user-attachments/assets/783986e9-a719-4965-aa97-c0c05d986f47">

2. 카프카 설정

3. 카프카 연동 테스트 작성

## [의사결정]
1. `zookeeper`와 `kafka`를 한 번에 컨테이너에 올릴 수 있도록 `docker-compose`를 작성하였습니다.
2. offset을 직접 통제하기 위해 `enable-auto-commit: false`으로 offset 커밋을 수동 관리하였습니다.
3. 초기 개발 단계이므로 `max-poll-records: 500`(기본값)이면 충분하다고 판단되어 별도의 설정을 하지 않았습니다.
4. 테스트 시 리스너가 비동기로 처리하는 시간을 고려해 중간에 `Thread.sleep(2000);`를 삽입하였습니다.
5. 이번 주차에는 `임베디드 카프카`로 테스트를 진행해 보고 추후에 `테스트 컨테이너`를 적용해 보고자 합니다.

## [리뷰 포인트]
1. `"카프카 설정에서 불필요한 부분 혹은 보완해야 할 부분이 있는지?"`
2. `"카프카 연동 테스트는 적절했는지?"`에 대해서 리뷰 부탁드리겠습니다!
